### PR TITLE
NewGrpc config's changed as AuthenticationPort from UserPort

### DIFF
--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -133,7 +133,7 @@ func main() {
 		go pc_probe.NewProbeAPI().Serve(internalConfig.Restapi.ProbePort)
 	}
 	wg.Add(1)
-	go pc_grpc.NewGrpc(queryHandler, commandHandler).Serve(internalConfig.Grpc.UserPort)
+	go pc_grpc.NewGrpc(queryHandler, commandHandler).Serve(internalConfig.Grpc.AuthenticationPort)
 	wg.Wait()
 
 }


### PR DESCRIPTION
Closes #24 

The NewGrpc configuration in the main.go file has been updated to use the AuthenticationPort instead of the UserPort. This change is necessary because the configuration was originally set as UserPort when the service was cloned from the user service, but our desired service is the Authentication service.