### PR TITLE
UserServicePort added to infrastructure layer

### DIFF
--- a/internal/application/infrastructure/port/service/user.go
+++ b/internal/application/infrastructure/port/service/user.go
@@ -1,0 +1,15 @@
+package application
+
+import (
+	"context"
+
+	me "github.com/octoposprime/op-be-auth/internal/domain/model/entity"
+	mo "github.com/octoposprime/op-be-auth/internal/domain/model/object"
+)
+
+// UserServicePort is a port for Hexagonal Architecture Pattern.
+// It is used to communicate with the user service.
+type UserServicePort interface {
+	// CheckUserPassword checks the given user's password in the user service.
+	CheckUserPassword(ctx context.Context, loginRequest *mo.LoginRequest) (*me.User, error)
+}

--- a/internal/application/infrastructure/port/service/user_test.go
+++ b/internal/application/infrastructure/port/service/user_test.go
@@ -1,0 +1,1 @@
+package application


### PR DESCRIPTION
Closes #26 

The UserServicePort has been integrated into the infrastructure layer to facilitate data retrieval. After integrating an adapter to this port, we will verify if the password hash matches the recorded password hash in the database from the user service.