### PR TITLE
User Ports Removed from Command and Query Interfaces

### DIFF
--- a/internal/application/presentation/port/command/command.go
+++ b/internal/application/presentation/port/command/command.go
@@ -5,5 +5,4 @@ package application
 type CommandPort interface {
 	LoggingCommandPort
 	AuthenticationCommandPort
-	UserCommandPort
 }

--- a/internal/application/presentation/port/query/query.go
+++ b/internal/application/presentation/port/query/query.go
@@ -3,5 +3,4 @@ package application
 // QueryPort is a port for Hexagonal Architecture Pattern.
 // It is used to communicate with the application layer.
 type QueryPort interface {
-	UserQueryPort
 }


### PR DESCRIPTION
Close #31 

internal/application/presentation/port/command/command.go
internal/application/presentation/port/query/query.go 

Removed user ports from **command.go** and **query.go** files in directories.
