### PR TITLE
Removed user related DB operations from DbPort.

### DIFF
--- a/internal/application/infrastructure/port/repository/db.go
+++ b/internal/application/infrastructure/port/repository/db.go
@@ -3,8 +3,6 @@ package application
 import (
 	"context"
 
-	"github.com/google/uuid"
-	me "github.com/octoposprime/op-be-auth/internal/domain/model/entity"
 	pb_logging "github.com/octoposprime/op-be-shared/pkg/proto/pb/logging"
 )
 
@@ -13,10 +11,4 @@ import (
 type DbPort interface {
 	// SetLogger sets logging call-back function
 	SetLogger(LogFunc func(ctx context.Context, logData *pb_logging.LogData) (*pb_logging.LoggingResult, error))
-
-	// GetUsersByFilter returns the users that match the given filter.
-	GetUsersByFilter(ctx context.Context, userFilter me.UserFilter) (me.Users, error)
-
-	// GetUserPasswordByUserId returns active password of the given user.
-	GetUserPasswordByUserId(ctx context.Context, userId uuid.UUID) (me.UserPassword, error)
 }


### PR DESCRIPTION
Closes #39 

 This update involves modifying the DbPort interface in the **internal/application/infrastructure/port/repository/db.go** file to align with recent architectural changes. In the revised interface, direct management of user-related database operations via this port is eliminated.

The entire content of db.go has been replaced with the provided code snippet to reflect these changes accurately.